### PR TITLE
feat: implement file download signing endpoint

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -85,9 +85,43 @@
     },
     "/v1/file/download": {
       "get": {
-        "summary": "Get signed download url (mock)",
-        "parameters": [{ "name": "file_id", "in": "query", "schema": { "type": "string" }, "required": true }],
-        "responses": { "200": { "description": "ok" } }
+        "summary": "Get signed download url",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "query",
+            "schema": { "type": "string" },
+            "required": true,
+            "description": "ID of the file to download"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Signed download url",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "integer", "example": 0 },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "url": { "type": "string", "format": "uri" },
+                        "expiresInSec": { "type": "integer", "example": 180 }
+                      },
+                      "required": ["url", "expiresInSec"]
+                    }
+                  },
+                  "required": ["code", "data"]
+                }
+              }
+            }
+          },
+          "400": { "description": "Missing file_id" },
+          "404": { "description": "File not found" },
+          "500": { "description": "Internal server error" }
+        }
       }
     },
     "/v1/db/ping": { "get": { "summary": "DB connectivity check", "responses": { "200": { "description": "ok" } } } },

--- a/apps/api/src/modules/file/index.js
+++ b/apps/api/src/modules/file/index.js
@@ -1,0 +1,77 @@
+import { prisma } from "../../db.js";
+import { getSignedUrl } from "../../../../../packages/adapters/cos/index.js";
+
+const EXPIRES_IN_SEC = 180;
+
+function resolveClientIp(req) {
+  const xfwd = req.headers["x-forwarded-for"];
+  if (typeof xfwd === "string" && xfwd.trim()) {
+    const [first] = xfwd.split(",");
+    if (first && first.trim()) return first.trim();
+  }
+  return req.ip;
+}
+
+function logAccess(logger, payload) {
+  const entry = {
+    ...payload,
+    ts: new Date().toISOString(),
+  };
+  if (logger && typeof logger.info === "function") {
+    logger.info("[file.download]", entry);
+  } else {
+    console.info("[file.download]", entry);
+  }
+}
+
+export function registerFileModule(app, { logger = console } = {}) {
+  app.get("/v1/file/download", async (req, res) => {
+    const queryValue = req.query?.file_id;
+    const fileId = Array.isArray(queryValue) ? queryValue[0] : queryValue;
+    const normalizedId = typeof fileId === "string" ? fileId.trim() : "";
+
+    if (!normalizedId) {
+      return res.status(400).json({ code: 400, msg: "missing file_id" });
+    }
+
+    try {
+      let record = null;
+      const hasDb = Boolean(process.env.DB_URL);
+      if (hasDb) {
+        try {
+          record = await prisma.fileObject.findUnique({ where: { id: normalizedId } });
+        } catch (dbError) {
+          if (logger && typeof logger.warn === "function") {
+            logger.warn("[file.download] db lookup failed", dbError);
+          } else {
+            console.warn("[file.download] db lookup failed", dbError);
+          }
+        }
+      }
+
+      const key = record?.cos_key || record?.id || normalizedId;
+
+      if (!key) {
+        return res.status(404).json({ code: 404, msg: "file not found" });
+      }
+
+      const url = await getSignedUrl(key, { expiresInSec: EXPIRES_IN_SEC });
+
+      logAccess(logger, {
+        file_id: normalizedId,
+        key,
+        ip: resolveClientIp(req),
+        ua: req.headers["user-agent"] || "",
+      });
+
+      return res.json({ code: 0, data: { url, expiresInSec: EXPIRES_IN_SEC } });
+    } catch (error) {
+      if (logger && typeof logger.error === "function") {
+        logger.error("[file.download]", error);
+      } else {
+        console.error("[file.download]", error);
+      }
+      return res.status(500).json({ code: 500, msg: "internal error" });
+    }
+  });
+}

--- a/apps/api/src/openapi.json
+++ b/apps/api/src/openapi.json
@@ -85,9 +85,43 @@
     },
     "/v1/file/download": {
       "get": {
-        "summary": "Get signed download url (mock)",
-        "parameters": [{ "name": "file_id", "in": "query", "schema": { "type": "string" }, "required": true }],
-        "responses": { "200": { "description": "ok" } }
+        "summary": "Get signed download url",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "query",
+            "schema": { "type": "string" },
+            "required": true,
+            "description": "ID of the file to download"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Signed download url",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "integer", "example": 0 },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "url": { "type": "string", "format": "uri" },
+                        "expiresInSec": { "type": "integer", "example": 180 }
+                      },
+                      "required": ["url", "expiresInSec"]
+                    }
+                  },
+                  "required": ["code", "data"]
+                }
+              }
+            }
+          },
+          "400": { "description": "Missing file_id" },
+          "404": { "description": "File not found" },
+          "500": { "description": "Internal server error" }
+        }
       }
     },
     "/v1/db/ping": { "get": { "summary": "DB connectivity check", "responses": { "200": { "description": "ok" } } } },

--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -140,16 +140,8 @@ app.post("/v1/analysis/report", (req, res) => {
 });
 
 // 文件下载占位：?file_id=xxx -> 返回临时URL
-import { getSignedUrl } from "../../../packages/adapters/cos/index.js";
-app.get("/v1/file/download", async (req, res) => {
-  try {
-    const fileId = String(req.query.file_id || "demo.pdf");
-    const url = await getSignedUrl(fileId);
-    res.json({ code: 0, data: { url } });
-  } catch (e) {
-    res.status(500).json({ code: 500, msg: e?.message || "error" });
-  }
-});
+import { registerFileModule } from "./modules/file/index.js";
+registerFileModule(app);
 
 // ===== Auth: /v1/auth/wx/callback（占位，使用 code 换本地假用户，签发 JWT）=====
 import jwt from "jsonwebtoken";


### PR DESCRIPTION
## Summary
- add a dedicated file module that generates signed download URLs, handles DB lookup fallbacks, and logs access details
- wire the new module into the API server and document the endpoint response/ errors in the OpenAPI specs

## Testing
- pnpm --filter @wxresume/api test
- curl -s "http://localhost:8080/v1/file/download?file_id=demo.pdf"

------
https://chatgpt.com/codex/tasks/task_e_68e4bfb0e720832e95122a2647086e44